### PR TITLE
Reduce image final size by merging run statements

### DIFF
--- a/deegree-builtin-tomcat/Dockerfile
+++ b/deegree-builtin-tomcat/Dockerfile
@@ -10,9 +10,9 @@ ENV DEEGREE_VERSION 3.3.18
 RUN wget http://repo.deegree.org/content/repositories/public/org/deegree/deegree-webservices/${DEEGREE_VERSION}/deegree-webservices-${DEEGREE_VERSION}.zip -O /tmp/deegree.zip
 
 # unpack 
-RUN unzip /tmp/deegree.zip -d /opt/
-RUN ln -s /opt/deegree-webservices-${DEEGREE_VERSION}/ /opt/deegree
-RUN rm /tmp/deegree.zip
+RUN unzip /tmp/deegree.zip -d /opt/ && \
+    ln -s /opt/deegree-webservices-${DEEGREE_VERSION}/ /opt/deegree && \
+    rm /tmp/deegree.zip
 
 # run tomcat
 CMD /opt/deegree/bin/catalina.sh run


### PR DESCRIPTION
The 'RUN rm /tmp/deegree.zip' command does not reduce the final image size, it creates a new, useless layer.
This patch addresses it by merging the 3 RUN statements into a single one.
